### PR TITLE
Remove fix protocol from webfont url

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,5 +1,5 @@
 @import url("font-awesome.min.css");
-@import url("http://fonts.googleapis.com/css?family=Lato:300,400,900");
+@import url("//fonts.googleapis.com/css?family=Lato:300,400,900");
 
 /*
 	Twenty by HTML5 UP

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -2,7 +2,7 @@
 @import 'libs/functions';
 @import 'libs/mixins';
 @import url("font-awesome.min.css");
-@import url("http://fonts.googleapis.com/css?family=Lato:300,400,900");
+@import url("//fonts.googleapis.com/css?family=Lato:300,400,900");
 
 /*
 	Twenty by HTML5 UP


### PR DESCRIPTION
When I tried to deploy this theme to a https website I noticed the missing webfonts. This patch fixes this issues.