### PR TITLE
Make image links optional in portfolio

### DIFF
--- a/templates/modular/portfolio.html.twig
+++ b/templates/modular/portfolio.html.twig
@@ -9,7 +9,11 @@
             {% for item in row %}
                 <div class="6u 12u(narrower)">
                     <section>
-                        <a href="{{ item.image_link }}" class="image featured"><img src="{{ page.media[item.image].url }}" alt="" /></a>
+                        {% if item.image_link %}
+                            <a href="{{ item.image_link }}" class="image featured"><img src="{{ page.media[item.image].url }}" alt="" /></a>
+                        {% else %}
+                            <span class="image featured"><img src="{{ page.media[item.image].url }}" alt="" /></span>
+                        {% endif %}
                         <header>
                             <h3>{{ item.title }}</h3>
                         </header>


### PR DESCRIPTION
When removing the image_link item from the yaml, the template still links the image (to nowhere / the current page.) It should probably just remove the link to avoid confusion.