### PR TITLE
Only show submenu when one is defined

### DIFF
--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -21,6 +21,7 @@
             <a href="{{ mitem.link }}">{{ mitem.text }}</a>
           </li>
           {% endfor %}
+          {% if site.submenu %}
           <li class="submenu">
             <a href="">Submenu</a>
             <ul>
@@ -29,6 +30,7 @@
               {% endfor %}
             </ul>
           </li>
+          {% endif %}
         </ul>
       </li>
 


### PR DESCRIPTION
Much like my other PR, if someone removes the submenu they probably don't want the word "Submenu" to still be hanging around with a blank submenu